### PR TITLE
Hackathon leads sourcing

### DIFF
--- a/activities/leads_source.md
+++ b/activities/leads_source.md
@@ -1,0 +1,24 @@
+Sourcing hackathon leads ICPDAO can apply for.
+Uniswap Gitcoin hackathon 9:
+https://gitcoin.co/issue/unigrants/ugp-hacks/1/100025056
+
+The UNI Grants Program is providing 4 prizes in UNI totaling $20,000 USD in hackathon bounties for building the most the innovative hacks and best solutions tackling one of our challenges and focus areas.
+
+The Innovation track has no limits so let your imagination run wild for what you'd wish Uniswap had or how you'd want Uniswap to be better...
+
+Enhancing the trading experience
+Make LPing and/or analytics more accessible
+Sybil and Token Lists are also fair game!
+Build Something That Improves Eth2:
+https://gitcoin.co/issue/gitcoinco/skunkworks/200/100025061
+Bounty
+10k DAI awarded to the best submission that meets basic quality standards.
+
+If there are multiple great submissions, we will award smaller bounties (2-5k DAI) to a few others at our discretion.
+
+Challenge description
+The EF is supporting hacks that improve Eth2. There are 3 categories we're most interested in:
+
+tools to improve the staking experience
+new mainnet data analysis or visualization
+community or educational content


### PR DESCRIPTION
for https://github.com/icpdao/icp/issues/7
collected hankathon leads, and confirm follow "Uniswap Gitcoin hackathon 9"